### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/hashpire/a8e60057-0fb2-4c91-950d-8e8a3863f157/8b141bb8-266d-4d18-8c1a-ddb4b73cf8ae/_apis/work/boardbadge/abd211b0-b2e7-45e1-b2a2-7d64cfa25ec0)](https://dev.azure.com/hashpire/a8e60057-0fb2-4c91-950d-8e8a3863f157/_boards/board/t/8b141bb8-266d-4d18-8c1a-ddb4b73cf8ae/Microsoft.RequirementCategory)
 # Hashpire.com
 Inspiring the world with the power of hash


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#2](https://dev.azure.com/hashpire/a8e60057-0fb2-4c91-950d-8e8a3863f157/_workitems/edit/2). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.